### PR TITLE
do not force dash

### DIFF
--- a/FormCountrySelectMenu.php
+++ b/FormCountrySelectMenu.php
@@ -14,7 +14,7 @@ class FormCountrySelectMenu extends FormSelectMenu
     public function addAttributes($arrAttributes)
     {
         parent::addAttributes($arrAttributes);
-        $arrOptions = array(array('label' => ($this->placeholder == '' ? '-' : $this->placeholder), 'value' => ''));
+        $arrOptions = array(array('label' => $this->placeholder, 'value' => ''));
         $arrCountries = $this->getCountries();
 
         foreach ($arrCountries as $short => $name) {


### PR DESCRIPTION
Imho it is better to always just use the placeholder and not force a dash for the empty option.

The dash can be replaced for regular select menus via the `loadFormField` hook - however this is not possible with the country select menu, because the countries are added to the options of the widget in the `addAttributes` method, which will be executed _after_ the `loadFormField` hook.