### PR TITLE
Fix type error

### DIFF
--- a/src/Widget/FormCountrySelect.php
+++ b/src/Widget/FormCountrySelect.php
@@ -29,7 +29,7 @@ class FormCountrySelect extends FormSelect
         }
 
         // Replace insert tags
-        if (str_contains($this->varValue, '{{')) {
+        if (str_contains($this->varValue ?? '', '{{')) {
             $this->varValue = System::getContainer()->get('contao.insert_tag.parser')->parse($this->varValue);
         }
 


### PR DESCRIPTION
Fixes the following error:

```
TypeError:
str_contains(): Argument #1 ($haystack) must be of type string, null given

  at terminal42\contao-countryselect\src\Widget\FormCountrySelect.php:32
  at str_contains(null, '{{')
     (terminal42\contao-countryselect\src\Widget\FormCountrySelect.php:32)
  at Terminal42\CountryselectBundle\Widget\FormCountrySelect->addAttributes(null)
     (contao\core-bundle\src\Resources\contao\library\Contao\Widget.php:592)
  at Contao\Widget->parse(null)
     (contao\core-bundle\src\Resources\contao\forms\FormSelectMenu.php:211)
  at Contao\FormSelectMenu->parse()
     (contao\core-bundle\src\Resources\contao\forms\Form.php:248)
  at Contao\Form->compile()
     (contao\core-bundle\src\Resources\contao\classes\Hybrid.php:230)
  at Contao\Hybrid->generate()
     (contao\core-bundle\src\Resources\contao\forms\Form.php:90)
  at Contao\Form->generate()
     (contao\core-bundle\src\Resources\contao\library\Contao\Controller.php:616)
```